### PR TITLE
git-lfs support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Pkg-builder simplifies the process of creating packages for Linux distributions.
 If you are using Debian, install sbuild, and various dependencies:
 
 ```bash
-sudo apt install libssl-dev pkg-config quilt debhelper tar wget autopkgtest vmdb2 qemu-system-x86
+sudo apt install libssl-dev pkg-config quilt debhelper tar wget autopkgtest vmdb2 qemu-system-x86 git-lfs
 sudo sbuild-adduser `whoami`
 
 # Install sbuild

--- a/src/v1/build/dir_setup.rs
+++ b/src/v1/build/dir_setup.rs
@@ -76,6 +76,11 @@ pub fn update_submodules(git_submodules: &Vec<SubModule>, current_dir: &str) -> 
 }
 
 pub fn clone_and_checkout_tag(git_url: &str, tag_version: &str, path: &str, git_submodules: &Vec<SubModule>) -> Result<()> {
+    match Command::new("which").arg("git-lfs").output() {
+        Ok(_) => Ok(()),
+        Err(_) => Err(eyre!("git-lfs is not installed, please install it!")),
+    }?;
+
     let output = Command::new("git")
         .args(&["clone", "--depth", "1", "--branch", tag_version, git_url, path])
         .output()


### PR DESCRIPTION
If you tar a git repository which has >100m, git silently ignores those files, but not when git-lfs is installed. 