### PR TITLE
chore: remove curl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "pkg-builder"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkg-builder"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/bookworm/c/hello-world/pkg-builder.toml
+++ b/examples/bookworm/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/dotnet/hello-world/pkg-builder.toml
+++ b/examples/bookworm/dotnet/hello-world/pkg-builder.toml
@@ -32,7 +32,7 @@ use_backup_version = true
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version = "0.2.5"
+pkg_builder_version = "0.2.6"
 debcrafter_version = "2711b53"
 run_lintian = true
 run_piuparts = true

--- a/examples/bookworm/git-package/nimbus/pkg-builder.toml
+++ b/examples/bookworm/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/bookworm/go/hello-world/pkg-builder.toml
+++ b/examples/bookworm/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/bookworm/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/java/hello-world/pkg-builder.toml
+++ b/examples/bookworm/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/javascript/hello-world/pkg-builder.toml
+++ b/examples/bookworm/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/nim/hello-world/pkg-builder.toml
+++ b/examples/bookworm/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/rust/hello-world/pkg-builder.toml
+++ b/examples/bookworm/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/typescript/hello-world/pkg-builder.toml
+++ b/examples/bookworm/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/virtual/hello-world/pkg-builder.toml
+++ b/examples/bookworm/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/c/hello-world/pkg-builder.toml
+++ b/examples/jammy/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/dotnet/hello-world/pkg-builder.toml
+++ b/examples/jammy/dotnet/hello-world/pkg-builder.toml
@@ -31,7 +31,7 @@ use_backup_version = true
 [build_env]
 codename = "jammy jellyfish"
 arch = "amd64"
-pkg_builder_version = "0.2.5"
+pkg_builder_version = "0.2.6"
 debcrafter_version = "2711b53"
 run_lintian = true
 run_piuparts = true

--- a/examples/jammy/git-package/nimbus/pkg-builder.toml
+++ b/examples/jammy/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/jammy/go/hello-world/pkg-builder.toml
+++ b/examples/jammy/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/jammy/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/java/hello-world/pkg-builder.toml
+++ b/examples/jammy/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/javascript/hello-world/pkg-builder.toml
+++ b/examples/jammy/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/nim/hello-world/pkg-builder.toml
+++ b/examples/jammy/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/rust/hello-world/pkg-builder.toml
+++ b/examples/jammy/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/typescript/hello-world/pkg-builder.toml
+++ b/examples/jammy/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/virtual/hello-world/pkg-builder.toml
+++ b/examples/jammy/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/c/hello-world/pkg-builder.toml
+++ b/examples/noble/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/dotnet/hello-world/pkg-builder.toml
+++ b/examples/noble/dotnet/hello-world/pkg-builder.toml
@@ -36,7 +36,7 @@ use_backup_version = true
 [build_env]
 codename = "noble numbat"
 arch = "amd64"
-pkg_builder_version = "0.2.5"
+pkg_builder_version = "0.2.6"
 debcrafter_version = "2711b53"
 run_lintian = true
 run_piuparts = true

--- a/examples/noble/git-package/nimbus/pkg-builder.toml
+++ b/examples/noble/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/noble/go/hello-world/pkg-builder.toml
+++ b/examples/noble/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/noble/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/java/hello-world/pkg-builder.toml
+++ b/examples/noble/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/javascript/hello-world/pkg-builder.toml
+++ b/examples/noble/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/nim/hello-world/pkg-builder.toml
+++ b/examples/noble/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/rust/hello-world/pkg-builder.toml
+++ b/examples/noble/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/typescript/hello-world/pkg-builder.toml
+++ b/examples/noble/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/virtual/hello-world/pkg-builder.toml
+++ b/examples/noble/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=true
 run_piuparts=true

--- a/src/v1/build/dir_setup.rs
+++ b/src/v1/build/dir_setup.rs
@@ -426,6 +426,10 @@ pub fn setup_sbuild() -> Result<()> {
 }
 
 pub fn copy_directory_recursive(src_dir: &Path, dest_dir: &Path) -> Result<(), io::Error> {
+    if !src_dir.exists() {
+        return Err(io::Error::new(io::ErrorKind::NotFound, format!("Source directory {:?} does not exist", src_dir)));
+    }
+
     if !dest_dir.exists() {
         fs::create_dir_all(dest_dir)?;
     }
@@ -440,7 +444,10 @@ pub fn copy_directory_recursive(src_dir: &Path, dest_dir: &Path) -> Result<(), i
         if entry_path.is_dir() {
             copy_directory_recursive(&entry_path, &dest_path)?;
         } else {
-            fs::copy(&entry_path, &dest_path)?;
+            if let Err(e) = fs::copy(&entry_path, &dest_path) {
+                eprintln!("Failed to copy file from {:?} to {:?}: {}", entry_path, dest_path, e);
+                return Err(e);
+            }
         }
     }
 

--- a/src/v1/build/sbuild.rs
+++ b/src/v1/build/sbuild.rs
@@ -44,7 +44,7 @@ impl Sbuild {
                 let rust_binary_gpg_asc = &config.rust_binary_gpg_asc;
                 let lang_deps = vec![
                     "apt install -y wget gpg gpg-agent".to_string(),
-                    format!("cd /tmp && wget -o rust.tar.xz {}", rust_binary_url),
+                    format!("cd /tmp && wget -O  rust.tar.xz {}", rust_binary_url),
                     format!(
                         "cd /tmp && echo \"{}\" >> rust.tar.xz.asc && cat rust.tar.xz.asc ",
                         rust_binary_gpg_asc
@@ -65,7 +65,7 @@ impl Sbuild {
                 let go_binary_checksum = &config.go_binary_checksum;
                 let install = vec![
                     "apt install -y wget".to_string(),
-                    format!("cd /tmp && wget -o go.tar.gz {}", go_binary_url),
+                    format!("cd /tmp && wget -O  go.tar.gz {}", go_binary_url),
                     format!("cd /tmp && echo \"{} go.tar.gz\" >> hash_file.txt && cat hash_file.txt", go_binary_checksum),
                     "cd /tmp && sha256sum -c hash_file.txt".to_string(),
                     "cd /tmp && rm -rf /usr/local/go && mkdir /usr/local/go && tar -C /usr/local -xzf go.tar.gz".to_string(),
@@ -83,7 +83,7 @@ impl Sbuild {
                 let node_binary_checksum = &config.node_binary_checksum;
                 let mut install = vec![
                     "apt install -y wget".to_string(),
-                    format!("cd /tmp && wget -o node.tar.gz {}", node_binary_url),
+                    format!("cd /tmp && wget -O  node.tar.gz {}", node_binary_url),
                     format!("cd /tmp && echo \"{} node.tar.gz\" >> hash_file.txt && cat hash_file.txt", node_binary_checksum),
                     "cd /tmp && sha256sum -c hash_file.txt".to_string(),
                     "cd /tmp && rm -rf /usr/share/node && mkdir /usr/share/node && tar -C /usr/share/node -xzf node.tar.gz --strip-components=1".to_string(),

--- a/src/v1/build/sbuild.rs
+++ b/src/v1/build/sbuild.rs
@@ -43,18 +43,18 @@ impl Sbuild {
                 let rust_binary_url = &config.rust_binary_url;
                 let rust_binary_gpg_asc = &config.rust_binary_gpg_asc;
                 let lang_deps = vec![
-                    "apt install -y curl gpg gpg-agent".to_string(),
-                    format!("cd /tmp && curl -o rust.tar.xz -L {}", rust_binary_url),
+                    "apt install -y wget gpg gpg-agent".to_string(),
+                    format!("cd /tmp && wget -o rust.tar.xz {}", rust_binary_url),
                     format!(
                         "cd /tmp && echo \"{}\" >> rust.tar.xz.asc && cat rust.tar.xz.asc ",
                         rust_binary_gpg_asc
                     ),
-                    "curl https://keybase.io/rust/pgp_keys.asc | gpg --import".to_string(),
+                    "wget -qO- https://keybase.io/rust/pgp_keys.asc | gpg --import".to_string(),
                     "cd /tmp && gpg --verify rust.tar.xz.asc rust.tar.xz".to_string(),
                     "cd /tmp && tar xvJf rust.tar.xz -C . --strip-components=1 --exclude=rust-docs"
                         .to_string(),
                     "cd /tmp && /bin/bash install.sh --without=rust-docs".to_string(),
-                    "apt remove -y curl gpg gpg-agent".to_string(),
+                    "apt remove -y wget gpg gpg-agent".to_string(),
                 ];
                 lang_deps
             }
@@ -64,8 +64,8 @@ impl Sbuild {
                 let go_binary_url = &config.go_binary_url;
                 let go_binary_checksum = &config.go_binary_checksum;
                 let install = vec![
-                    "apt install -y curl".to_string(),
-                    format!("cd /tmp && curl -o go.tar.gz -L {}", go_binary_url),
+                    "apt install -y wget".to_string(),
+                    format!("cd /tmp && wget -o go.tar.gz {}", go_binary_url),
                     format!("cd /tmp && echo \"{} go.tar.gz\" >> hash_file.txt && cat hash_file.txt", go_binary_checksum),
                     "cd /tmp && sha256sum -c hash_file.txt".to_string(),
                     "cd /tmp && rm -rf /usr/local/go && mkdir /usr/local/go && tar -C /usr/local -xzf go.tar.gz".to_string(),
@@ -73,7 +73,7 @@ impl Sbuild {
                     "go version".to_string(),
                     // add write permission, this is a chroot env, with one user, should be fine
                     "chmod -R a+rwx /usr/local/go/pkg".to_string(),
-                    "apt remove -y curl".to_string(),
+                    "apt remove -y wget".to_string(),
                 ];
                 install
             }
@@ -82,8 +82,8 @@ impl Sbuild {
                 let node_binary_url = &config.node_binary_url;
                 let node_binary_checksum = &config.node_binary_checksum;
                 let mut install = vec![
-                    "apt install -y curl".to_string(),
-                    format!("cd /tmp && curl -o node.tar.gz -L {}", node_binary_url),
+                    "apt install -y wget".to_string(),
+                    format!("cd /tmp && wget -o node.tar.gz {}", node_binary_url),
                     format!("cd /tmp && echo \"{} node.tar.gz\" >> hash_file.txt && cat hash_file.txt", node_binary_checksum),
                     "cd /tmp && sha256sum -c hash_file.txt".to_string(),
                     "cd /tmp && rm -rf /usr/share/node && mkdir /usr/share/node && tar -C /usr/share/node -xzf node.tar.gz --strip-components=1".to_string(),
@@ -92,7 +92,7 @@ impl Sbuild {
                     "ln -s /usr/share/node/bin/npm /usr/bin/npm".to_string(),
                     "ln -s /usr/share/node/bin/npx /usr/bin/npx".to_string(),
                     "ln -s /usr/share/node/bin/corepack /usr/bin/corepack".to_string(),
-                    "apt remove -y curl".to_string(),
+                    "apt remove -y wget".to_string(),
                     "node --version".to_string(),
                     "npm --version".to_string(),
                 ];

--- a/src/v1/pkg_config.rs
+++ b/src/v1/pkg_config.rs
@@ -587,7 +587,7 @@ go_version = "1.22"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.5"
+pkg_builder_version="0.2.6"
 debcrafter_version = "2711b53"
 run_lintian=false
 run_piuparts=false
@@ -618,7 +618,7 @@ workdir="~/.pkg-builder/packages/jammy"
             build_env: BuildEnv {
                 codename: "bookworm".to_string(),
                 arch: "amd64".to_string(),
-                pkg_builder_version: "0.2.5".to_string(),
+                pkg_builder_version: "0.2.6".to_string(),
                 debcrafter_version: "2711b53".to_string(),
                 sbuild_cache_dir: None,
                 docker: None,


### PR DESCRIPTION
Debian removed curl, because of openssl vulnebarility. This is a workaround, as it won't affect the built packages.