### PR TITLE
chore: update backported dotnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "pkg-builder"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkg-builder"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 build = "src/build.rs"
 

--- a/examples/bookworm/c/hello-world/pkg-builder.toml
+++ b/examples/bookworm/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/dotnet/hello-world/pkg-builder.toml
+++ b/examples/bookworm/dotnet/hello-world/pkg-builder.toml
@@ -32,7 +32,7 @@ use_backup_version = true
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version = "0.2.8"
+pkg_builder_version = "0.2.9"
 debcrafter_version = "8189263"
 run_lintian = true
 run_piuparts = true

--- a/examples/bookworm/git-package/nimbus/pkg-builder.toml
+++ b/examples/bookworm/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/bookworm/go/hello-world/pkg-builder.toml
+++ b/examples/bookworm/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/bookworm/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/java/hello-world/pkg-builder.toml
+++ b/examples/bookworm/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename = "bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/javascript/hello-world/pkg-builder.toml
+++ b/examples/bookworm/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/nim/hello-world/pkg-builder.toml
+++ b/examples/bookworm/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/python/hello-world/pkg-builder.toml
+++ b/examples/bookworm/python/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "python"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/rust/hello-world/pkg-builder.toml
+++ b/examples/bookworm/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/typescript/hello-world/pkg-builder.toml
+++ b/examples/bookworm/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/bookworm/virtual/hello-world/pkg-builder.toml
+++ b/examples/bookworm/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/c/hello-world/pkg-builder.toml
+++ b/examples/jammy/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/dotnet/hello-world/pkg-builder.toml
+++ b/examples/jammy/dotnet/hello-world/pkg-builder.toml
@@ -31,7 +31,7 @@ use_backup_version = true
 [build_env]
 codename = "jammy jellyfish"
 arch = "amd64"
-pkg_builder_version = "0.2.8"
+pkg_builder_version = "0.2.9"
 debcrafter_version = "8189263"
 run_lintian = true
 run_piuparts = true

--- a/examples/jammy/git-package/nimbus/pkg-builder.toml
+++ b/examples/jammy/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/jammy/go/hello-world/pkg-builder.toml
+++ b/examples/jammy/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/jammy/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/java/hello-world/pkg-builder.toml
+++ b/examples/jammy/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/javascript/hello-world/pkg-builder.toml
+++ b/examples/jammy/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/nim/hello-world/pkg-builder.toml
+++ b/examples/jammy/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/rust/hello-world/pkg-builder.toml
+++ b/examples/jammy/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/typescript/hello-world/pkg-builder.toml
+++ b/examples/jammy/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/jammy/virtual/hello-world/pkg-builder.toml
+++ b/examples/jammy/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="jammy jellyfish"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/c/hello-world/pkg-builder.toml
+++ b/examples/noble/c/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "c"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/dotnet/hello-world/pkg-builder.toml
+++ b/examples/noble/dotnet/hello-world/pkg-builder.toml
@@ -36,7 +36,7 @@ use_backup_version = true
 [build_env]
 codename = "noble numbat"
 arch = "amd64"
-pkg_builder_version = "0.2.8"
+pkg_builder_version = "0.2.9"
 debcrafter_version = "8189263"
 run_lintian = true
 run_piuparts = true

--- a/examples/noble/git-package/nimbus/pkg-builder.toml
+++ b/examples/noble/git-package/nimbus/pkg-builder.toml
@@ -70,7 +70,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "latest"
 run_lintian=false
 run_piuparts=false

--- a/examples/noble/go/hello-world/pkg-builder.toml
+++ b/examples/noble/go/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ go_binary_checksum = "5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/java-gradle/hello-world/pkg-builder.toml
+++ b/examples/noble/java-gradle/hello-world/pkg-builder.toml
@@ -26,7 +26,7 @@ gradle_binary_checksum="544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/java/hello-world/pkg-builder.toml
+++ b/examples/noble/java/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ jdk_binary_checksum="e4fb2df9a32a876afb0a6e17f54c594c2780e18badfa2e8fc99bc2656b0
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/javascript/hello-world/pkg-builder.toml
+++ b/examples/noble/javascript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/nim/hello-world/pkg-builder.toml
+++ b/examples/noble/nim/hello-world/pkg-builder.toml
@@ -20,7 +20,7 @@ nim_version_checksum = "047dde8ff40b18628ac1188baa9ca992d05f1f45c5121d1d07a76224
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/python/hello-world/pkg-builder.toml
+++ b/examples/noble/python/hello-world/pkg-builder.toml
@@ -17,7 +17,7 @@ language_env = "python"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/rust/hello-world/pkg-builder.toml
+++ b/examples/noble/rust/hello-world/pkg-builder.toml
@@ -37,7 +37,7 @@ KGFMBQELjcFWLGcBVE45DRuVR8E3XYunjSdgLFXjfZfeGF3uiS6fNHGCH41ryqfj
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/typescript/hello-world/pkg-builder.toml
+++ b/examples/noble/typescript/hello-world/pkg-builder.toml
@@ -21,7 +21,7 @@ yarn_version = "1.22.19"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/examples/noble/virtual/hello-world/pkg-builder.toml
+++ b/examples/noble/virtual/hello-world/pkg-builder.toml
@@ -11,7 +11,7 @@ package_type="virtual"
 [build_env]
 codename="noble numbat"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=true
 run_piuparts=true

--- a/src/v1/build/sbuild.rs
+++ b/src/v1/build/sbuild.rs
@@ -193,6 +193,11 @@ impl Sbuild {
                     install.push("apt remove -y wget".to_string());
           
                 } else if self.config.build_env.codename == "noble numbat" {
+                    // Note all the previous builds of dotnet fails, as they removed from main repo the dotnet packages
+                    // when new distrubution 24.10 released
+                    install.push("apt-get install software-properties-common -y".to_string());
+                    install.push("add-apt-repository ppa:dotnet/backports".to_string());
+                    install.push("apt-get update -y".to_string());
                     install.push("apt install -y wget".to_string());
                     for package in dotnet_packages {
                         let pkg = transform_name(&package.name, &self.config.build_env.arch);

--- a/src/v1/pkg_config.rs
+++ b/src/v1/pkg_config.rs
@@ -589,7 +589,7 @@ go_version = "1.22"
 [build_env]
 codename="bookworm"
 arch = "amd64"
-pkg_builder_version="0.2.8"
+pkg_builder_version="0.2.9"
 debcrafter_version = "8189263"
 run_lintian=false
 run_piuparts=false
@@ -620,7 +620,7 @@ workdir="~/.pkg-builder/packages/jammy"
             build_env: BuildEnv {
                 codename: "bookworm".to_string(),
                 arch: "amd64".to_string(),
-                pkg_builder_version: "0.2.8".to_string(),
+                pkg_builder_version: "0.2.9".to_string(),
                 debcrafter_version: "8189263".to_string(),
                 sbuild_cache_dir: None,
                 docker: None,


### PR DESCRIPTION
The new version of Ubuntu 24.10 is released, and dotnet got backported from the main repo. The repository must be added so dotnet can be installed. This change broke all the previously built packages, and the packages must be updated to use 0.2.9