### PR TITLE
ci: add weekly schedule and update bookworm verify hashes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * 0'    
   workflow_dispatch:
 
 env:
@@ -17,10 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup sbuild
         uses: ./.github/actions/setup-sbuild
-      
+
       - name: Build
         run: cargo build --verbose
 
@@ -47,10 +49,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup environment
         uses: ./.github/actions/setup-packaging-env
-        
+
       - name: Create chroot env
         run: |
           cd examples/bookworm/${{matrix.language}}/hello-world
@@ -84,10 +86,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup environment
         uses: ./.github/actions/setup-packaging-env
-        
+
       - name: Create chroot env
         run: |
           cd examples/jammy/${{matrix.language}}/hello-world
@@ -123,12 +125,12 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup environment
         uses: ./.github/actions/setup-packaging-env
         with:
           include_genisoimage: true
-      
+
       - name: Additional noble setup
         run: |
           sudo sbuild-adduser `whoami`
@@ -139,7 +141,7 @@ jobs:
       - name: Create chroot env
         run: |
           cd examples/noble/${{matrix.language}}/hello-world
-          pkg-builder env create 
+          pkg-builder env create
           echo "${HOME}/.cache/sbuild/noble-amd64.tar.gz" >> $GITHUB_PATH
 
       - name: Run packaging tests
@@ -149,4 +151,3 @@ jobs:
           language: ${{matrix.language}}
           run_piuparts: false
           run_autopkgtest: true
-          

--- a/examples/bookworm/c/hello-world/pkg-builder-verify.toml
+++ b/examples/bookworm/c/hello-world/pkg-builder-verify.toml
@@ -1,5 +1,5 @@
 [verify]
 package_hash=[
     {name= "hello-world_1.0.0-1.dsc", hash="924c9e4711c1f05e42817ec25027e8a43887cddc"},
-    {name= "hello-world_1.0.0-1_amd64.deb", hash="f809d1e6697717b1720ddfebc08519c9f525ae64"}
+    {name= "hello-world_1.0.0-1_amd64.deb", hash="c39f8042ef79564dfe8e6ccac6c183187bf6da7a"}
 ]

--- a/examples/bookworm/nim/hello-world/pkg-builder-verify.toml
+++ b/examples/bookworm/nim/hello-world/pkg-builder-verify.toml
@@ -3,5 +3,5 @@ package_hash=[
     { hash="7f193beb2ec74e4571fe6b035abfc124a431136e", name= "hello-world-nim_1.0.0-1.dsc"},
     { hash="a1b9eb72ce3b72094e6d815ff70208e7a88553cc", name= "hello-world-nim_1.0.0.orig.tar.gz"},
     { hash="abff1c040dab55f6cd93c68ea12dea5949ca8323", name= "hello-world-nim_1.0.0-1.debian.tar.xz"},
-    { hash="ca5e19eaf0dbdca7cea68549539114b9d8315603", name= "hello-world-nim_1.0.0-1_amd64.deb"},
+    { hash="bcdccba830294f424114257f475d50c7de0dfcb8", name= "hello-world-nim_1.0.0-1_amd64.deb"},
 ]

--- a/examples/bookworm/rust/hello-world/pkg-builder-verify.toml
+++ b/examples/bookworm/rust/hello-world/pkg-builder-verify.toml
@@ -3,5 +3,5 @@ package_hash=[
     { hash="d3aa1f40ca330f76b167d434f6bae999f50397e5", name= "hello-world-rust_1.0.0-1.dsc"},
     { hash="a9c7bea89015e52a5b4e24544873ec73a0c92af2", name= "hello-world-rust_1.0.0.orig.tar.gz"},
     { hash="6325d2f8fae0b4375e65960f85c524d7f09db8b4", name= "hello-world-rust_1.0.0-1.debian.tar.xz"},
-    { hash="a171d91d6c02b9f3b64d99b8bbbc60d72f5432e2", name= "hello-world-rust_1.0.0-1_amd64.deb"},
+    { hash="92a5b76ab75a980d92e1b52730425a3ff8c995ec", name= "hello-world-rust_1.0.0-1_amd64.deb"},
 ]


### PR DESCRIPTION
Add weekly cron trigger to tests workflow and clean up trailing whitespace. Update package verification hashes for bookworm C, Nim, and Rust hello-world examples.